### PR TITLE
Fix RSS feed metadata and markdown utilities

### DIFF
--- a/src/components/TelegramPostCard.astro
+++ b/src/components/TelegramPostCard.astro
@@ -1,67 +1,17 @@
 ---
 import { formatDate } from '@/utils/data.util';
+import { buildTextPreview } from '@/utils/markdown-text.util';
 import { extractTelegramTagsFromMarkdown } from '@/utils/telegram-tags.util';
-import { toString } from 'mdast-util-to-string';
-import remarkParse from 'remark-parse';
 import TelegramReactions from './TelegramReactions.astro';
 import Tags from './Tags.astro';
-import { unified } from 'unified';
 
 interface Props {
   post: any;
 }
 
 const { post } = Astro.props;
-const markdownParser = unified().use(remarkParse);
 const rawPostContent = typeof post.rawContent === 'function' ? post.rawContent() : '';
-
-// Get full post text body
-const getPostText = () => {
-  // Try rawContent first (gets markdown before compilation)
-  if (rawPostContent) {
-    // Remove frontmatter
-    return rawPostContent.replace(/^---[\s\S]*?---\n\n/, '').trim();
-  }
-  // Fallback to title
-  return post.frontmatter.title || '';
-};
-
-const markdownToPlainText = (markdown: string) => {
-  if (!markdown) return '';
-
-  try {
-    const tree = markdownParser.parse(markdown);
-    type MdastNode = Parameters<typeof toString>[0];
-    const children = Array.isArray((tree as { children?: unknown }).children)
-      ? ((tree as { children: MdastNode[] }).children)
-      : [tree as MdastNode];
-
-    return children
-      .map((node) => toString(node))
-      .filter((chunk) => chunk.trim().length > 0)
-      .join('\n\n');
-  } catch {
-    // Fallback to raw text if parser fails for malformed markdown
-    return markdown;
-  }
-};
-
-// Create text preview
-const getTextPreview = (text: string, maxLength: number = 250) => {
-  if (!text) return '';
-
-  const cleaned = markdownToPlainText(text)
-    .replace(/\r/g, '')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-  
-  if (cleaned.length <= maxLength) return cleaned;
-  return cleaned.slice(0, maxLength) + '...';
-};
-
-const fullText = getPostText();
-const textPreview = getTextPreview(fullText);
+const textPreview = buildTextPreview(rawPostContent, 250) || post.frontmatter.title || '';
 const postTags = extractTelegramTagsFromMarkdown(rawPostContent);
 
 const mediaList: string[] = Array.isArray(post.frontmatter.media) ? post.frontmatter.media : [];

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,23 +1,114 @@
-import rss, { pagesGlobToRssItems } from '@astrojs/rss';
+import rss from '@astrojs/rss';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { AppConfig } from '../utils/AppConfig';
+import { getFirstMeaningfulParagraph } from '../utils/markdown-text.util';
 
 export async function GET(context) {
-  // Get articles and Telegram posts
-  const [articles, telegramPosts] = await Promise.all([
-    pagesGlobToRssItems(import.meta.glob('./articles/*.{md,mdx}')),
-    pagesGlobToRssItems(import.meta.glob('./posts/*.md'))
+  const [articleEntries, postEntries] = await Promise.all([
+    loadEntries(import.meta.glob('./articles/*.{md,mdx}')),
+    loadEntries(import.meta.glob('./posts/*.md'))
   ]);
 
-  // Merge and sort by date
-  const allItems = [...articles, ...telegramPosts].sort((a, b) => {
-    return new Date(b.pubDate) - new Date(a.pubDate);
+  const [articleItems, postItems] = await Promise.all([
+    Promise.all(articleEntries.map(entryToArticleRssItem)),
+    Promise.all(postEntries.map(entryToPostRssItem))
+  ]);
+
+  const allItems = [...articleItems, ...postItems].sort((a, b) => {
+    const dateA = a.sortDate ? a.sortDate.getTime() : Number.NEGATIVE_INFINITY;
+    const dateB = b.sortDate ? b.sortDate.getTime() : Number.NEGATIVE_INFINITY;
+    return dateB - dateA;
   });
 
-  return rss({
-    title: 'nicdun.dev - blog',
-    description: 'Crafting the Digital Future with Web Development Wonders',
+  const latestDate = allItems.find((item) => item.sortDate)?.sortDate ?? new Date();
+  const language = AppConfig.locale === 'ru' ? 'ru-RU' : AppConfig.locale;
+  const feedSelfLink = new URL('/rss.xml', context.site).toString();
+  const rssItems = allItems.map(({ sortDate, ...item }) => item);
+
+  const response = await rss({
+    title: AppConfig.title,
+    description: AppConfig.description,
     site: context.site,
-    items: allItems,
+    items: rssItems,
     stylesheet: './rss/styles.xsl',
-    customData: `<language>en-us</language>`
+    xmlns: {
+      atom: 'http://www.w3.org/2005/Atom'
+    },
+    customData: [
+      `<language>${language}</language>`,
+      `<lastBuildDate>${latestDate.toUTCString()}</lastBuildDate>`,
+      `<atom:link href="${feedSelfLink}" rel="self" type="application/rss+xml" />`
+    ].join('')
   });
+
+  response.headers.set('Content-Type', 'application/xml; charset=utf-8');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+
+  return response;
+}
+
+async function loadEntries(globMap) {
+  return Promise.all(
+    Object.entries(globMap).map(async ([filePath, load]) => {
+      const module = await load();
+      return { filePath, module };
+    })
+  );
+}
+
+function getValidDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function getArticleDate(frontmatter) {
+  return getValidDate(frontmatter.createdDate ?? frontmatter.pubDate);
+}
+
+function getPostDate(frontmatter) {
+  return getValidDate(frontmatter.createdDate ?? frontmatter.publishDate);
+}
+
+async function getPostDescriptionFromBody(filePath, fallbackTitle) {
+  const sourcePath = resolve(process.cwd(), 'src/pages', filePath.replace(/^\.\//, ''));
+  const source = await readFile(sourcePath, 'utf8');
+  return getFirstMeaningfulParagraph(source) || fallbackTitle;
+}
+
+async function entryToPostRssItem(entry) {
+  const { module, filePath } = entry;
+  const { frontmatter, url } = module;
+  const parsedDate = getPostDate(frontmatter);
+  const description = await getPostDescriptionFromBody(filePath, frontmatter.title);
+
+  return {
+    title: frontmatter.title,
+    link: url,
+    description,
+    pubDate: parsedDate ?? new Date(0),
+    sortDate: parsedDate
+  };
+}
+
+async function entryToArticleRssItem(entry) {
+  const { module } = entry;
+  const { frontmatter, url } = module;
+  const parsedDate = getArticleDate(frontmatter);
+
+  return {
+    title: frontmatter.title,
+    link: url,
+    description: frontmatter.description ?? frontmatter.excerpt ?? frontmatter.title,
+    pubDate: parsedDate ?? new Date(0),
+    sortDate: parsedDate
+  };
 }

--- a/src/utils/markdown-text.util.ts
+++ b/src/utils/markdown-text.util.ts
@@ -1,0 +1,91 @@
+import { toString } from 'mdast-util-to-string';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const markdownParser = unified().use(remarkParse);
+
+export function stripFrontmatter(markdown: string): string {
+  if (!markdown) return '';
+  return markdown.replace(FRONTMATTER_RE, '');
+}
+
+function normalizeText(text: string): string {
+  return text
+    .replace(/\r/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*|__|~~/g, '')
+    .replace(/(^|\s)[*`~]+(?=\S)/g, '$1')
+    .replace(/(?<=\S)[*`~]+(?=\s|$|[.,!?;:])/g, '');
+}
+
+export function markdownToPlainText(markdown: string): string {
+  if (!markdown) return '';
+
+  try {
+    const tree = markdownParser.parse(markdown);
+    type MdastNode = Parameters<typeof toString>[0];
+    const children = Array.isArray((tree as { children?: unknown }).children)
+      ? (tree as { children: MdastNode[] }).children
+      : [tree as MdastNode];
+
+    const text = children
+      .map((node) => toString(node))
+      .filter((chunk) => chunk.trim().length > 0)
+      .join('\n\n');
+
+    return stripInlineMarkdown(text);
+  } catch {
+    // Fallback to raw markdown text if parser fails.
+    return stripInlineMarkdown(markdown);
+  }
+}
+
+function isMeaningfulParagraph(block: string): boolean {
+  const trimmed = block.trim();
+  if (!trimmed) return false;
+
+  if (/^#{1,6}\s/.test(trimmed)) return false;
+  if (/^>\s?/.test(trimmed)) return false;
+  if (/^([-*+]\s|\d+\.\s)/.test(trimmed)) return false;
+  if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) return false;
+  if (/^!\[[^\]]*]\(([^)]+)\)/.test(trimmed)) return false;
+
+  return true;
+}
+
+export function getFirstMeaningfulParagraph(markdown: string): string {
+  const bodyWithoutFrontmatter = stripFrontmatter(markdown)
+    .replace(/```[\s\S]*?```/g, '\n')
+    .replace(/~~~[\s\S]*?~~~/g, '\n');
+
+  const blocks = bodyWithoutFrontmatter
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const candidate = blocks.find(isMeaningfulParagraph);
+  if (!candidate) return '';
+
+  return normalizeText(markdownToPlainText(candidate));
+}
+
+export function buildTextPreview(markdown: string, maxLength: number = 250): string {
+  const cleaned = normalizeText(markdownToPlainText(stripFrontmatter(markdown)));
+  if (!cleaned) return '';
+  if (cleaned.length <= maxLength) return cleaned;
+
+  return cleaned.slice(0, maxLength) + '...';
+}


### PR DESCRIPTION
Summary
- replace glob-based RSS item flow with explicit article/post loading, normalize dates, and ensure every item has a pubDate/description
- add shared markdown-text utility for stripping frontmatter, locating the first meaningful paragraph, and reuse it in RSS and Telegram post cards
- update channel metadata to use AppConfig values, proper locale, atom link, and lastBuildDate while keeping the RSS stylesheet reference

Testing
- Not run (not requested)