### PR TITLE
Trigger GitHub Pages deploy from Telegram sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
@@ -29,6 +30,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/telegram-weekly-sync.yml
+++ b/.github/workflows/telegram-weekly-sync.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   telegram-weekly-sync:
     runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.commit_and_push.outputs.changed }}
 
     steps:
       - name: Checkout repository
@@ -34,6 +36,7 @@ jobs:
           TG_CHANNEL: ${{ vars.TG_CHANNEL }}
 
       - name: Commit and push changes to main
+        id: commit_and_push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -41,9 +44,33 @@ jobs:
           git add -A
 
           if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes to commit"
             exit 0
           fi
 
           git commit -m "chore(posts): weekly telegram sync"
           git push origin HEAD:main
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+  deploy-pages:
+    needs: telegram-weekly-sync
+    if: needs.telegram-weekly-sync.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Summary
- telegram-weekly-sync now records whether it committed changes and exposes that state to downstream jobs
- a conditional `deploy-pages` job runs right after the sync workflow only when new commits occur, handling checkout, Astro build, and Pages deployment with the required permissions and environment
- deploy.yml guards its build/deploy jobs against the automation bot so human pushes continue to use that workflow

Testing
- Not run (not requested)